### PR TITLE
use TLS to communicate with Consul Connect services

### DIFF
--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -1,6 +1,7 @@
 package dynamic
 
 import (
+	gtls "crypto/tls"
 	"reflect"
 	"time"
 
@@ -208,6 +209,8 @@ type ServersTransport struct {
 	Certificates        tls.Certificates    `description:"Certificates for mTLS." json:"certificates,omitempty" toml:"certificates,omitempty" yaml:"certificates,omitempty"`
 	MaxIdleConnsPerHost int                 `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, DefaultMaxIdleConnsPerHost is used" json:"maxIdleConnsPerHost,omitempty" toml:"maxIdleConnsPerHost,omitempty" yaml:"maxIdleConnsPerHost,omitempty" export:"true"`
 	ForwardingTimeouts  *ForwardingTimeouts `description:"Timeouts for requests forwarded to the backend servers." json:"forwardingTimeouts,omitempty" toml:"forwardingTimeouts,omitempty" yaml:"forwardingTimeouts,omitempty" export:"true"`
+	// TODO: Verify with traefik team if there is a better way to expose this
+	VerifyConnection func(*gtls.Config, gtls.ConnectionState) error `json:"-"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -476,10 +476,9 @@ func (p *Provider) watchConnectTLS(ctx context.Context) {
 	rootCerts := <-rootChan
 
 	certInfo := &connectCert{
-		service:            p.ServiceName,
-		insecureSkipVerify: p.Connect.InsecureSkipVerify,
-		root:               rootCerts,
-		leaf:               leafCerts,
+		service: p.ServiceName,
+		root:    rootCerts,
+		leaf:    leafCerts,
 	}
 
 	p.certChan <- certInfo

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -113,7 +113,7 @@ func (p *Provider) Init() error {
 func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.Pool) error {
 	if p.ConnectAware {
 		pool.GoCtx(p.registerConnectService)
-		pool.GoCtx(p.watchConnectTls)
+		pool.GoCtx(p.watchConnectTLS)
 	}
 
 	pool.GoCtx(func(routineCtx context.Context) {
@@ -318,10 +318,10 @@ func (p *Provider) registerConnectService(ctx context.Context) {
 		return
 	}
 
-	serviceId := uuid.New().String()
+	serviceID := uuid.New().String()
 	operation := func() error {
 		regReq := &api.AgentServiceRegistration{
-			ID:   serviceId,
+			ID:   serviceID,
 			Kind: api.ServiceKindTypical,
 			Name: p.ServiceName,
 			Port: p.ServicePort,
@@ -349,7 +349,7 @@ func (p *Provider) registerConnectService(ctx context.Context) {
 	}
 
 	<-ctx.Done()
-	err = client.Agent().ServiceDeregister(serviceId)
+	err = client.Agent().ServiceDeregister(serviceID)
 	if err != nil {
 		logger.WithError(err).Error("failed to deregister traefik from consul catalog")
 	}
@@ -400,7 +400,7 @@ func leafWatcherHandler(logger log.Logger, dest chan<- keyPair) func(watch.Block
 	}
 }
 
-func (p *Provider) watchConnectTls(ctx context.Context) {
+func (p *Provider) watchConnectTLS(ctx context.Context) {
 	ctxLog := log.With(ctx, log.Str(log.ProviderName, "consulcatalog"))
 	logger := log.FromContext(ctxLog)
 

--- a/pkg/server/service/roundtripper.go
+++ b/pkg/server/service/roundtripper.go
@@ -146,6 +146,11 @@ func createRoundTripper(cfg *dynamic.ServersTransport) (http.RoundTripper, error
 			RootCAs:            createRootCACertPool(cfg.RootCAs),
 			Certificates:       cfg.Certificates.GetCertificates(),
 		}
+		if cfg.VerifyConnection != nil {
+			transport.TLSClientConfig.VerifyConnection = func(cs tls.ConnectionState) error {
+				return cfg.VerifyConnection(transport.TLSClientConfig, cs)
+			}
+		}
 	}
 
 	return newSmartRoundTripper(transport)


### PR DESCRIPTION
Hi Gufran :)

## What does this PR do?
As mentioned in [this comment](https://github.com/traefik/traefik/pull/7407#issuecomment-762447022) on your PR to traefik, I've fixed the problems you were experiencing when trying to establish a TLS connection to a Consul Connect service

I decided to remove the "ConnectNative" configuration, since I couldn't find a way to use the Consul Connect package, without registering traefik as a Connect Native service and it simplified the configuration slightly to remove the option.

## Slightly off-topic stuff
I've only made small changes to your original design, but I'd like to do some additional work on it such as:

- Merging connect proxies and their upstream service into one service in traefik (right now, the connect service only works when using the name of the proxy service, i.e. web-sidecar-proxy.example.com connects to the proxy, while web.example.com connects to the upstream service)
- Ability to configure whether to use the non-connect service as a fallback in case traefik fails to use Consul Connect
- Separate service and certificate refresh intervals (maybe do certificate refreshes based on the time they expire)

I want to make sure, which of these ideas (if any), that you're onboard with, as it's your PR and you probably have some plans of your own.

I can make new PRs for these if you think any of the suggestions will be a good idea. Let me know what you think :) 